### PR TITLE
feat(admin): add Categories manager (CRUD with subcategories)\n\n- Ne…

### DIFF
--- a/src/components/access/AccessTab.tsx
+++ b/src/components/access/AccessTab.tsx
@@ -1448,29 +1448,46 @@ const AccessTab = ({ loading = false, error, setError, onTabChange, onEditUser }
                               </td>
                               <td className="px-6 py-3">
                                 <div className="flex flex-wrap gap-1">
-                                  {Object.entries((m as any).permissions || {}).filter(([,v]) => v).map(([k]) => (
-                                    <Badge key={k} variant="secondary" className="text-xs bg-green-100 text-green-800">{String(k)}</Badge>
-                                    <div className="text-xs text-gray-500">{m.email}</div>
-                                  </div>
-                                </div>
-                              </td>
-                              <td className="px-6 py-3">
-                                <div className="flex flex-wrap gap-1">
-                                  {Object.entries((m as any).permissions || {}).filter(([,v]) => v).map(([k]) => (
-                                    <Badge key={k} variant="secondary" className="text-xs bg-green-100 text-green-800">{String(k)}</Badge>
-                                  ))}
+                                  {Object.entries((m as any).permissions || {})
+                                    .filter(([, v]) => v)
+                                    .map(([k]) => (
+                                      <Badge
+                                        key={k}
+                                        variant="secondary"
+                                        className="text-xs bg-green-100 text-green-800"
+                                      >
+                                        {String(k)}
+                                      </Badge>
+                                    ))}
                                 </div>
                               </td>
                               <td className="px-6 py-3">
                                 <Badge className={`${getStatusColor(mStatus)} text-xs border`}>
-                                  <span className="flex items-center space-x-1">{getStatusIcon(mStatus)}<span>{mStatus}</span></span>
+                                  <span className="flex items-center space-x-1">
+                                    {getStatusIcon(mStatus)}
+                                    <span>{mStatus}</span>
+                                  </span>
                                 </Badge>
                               </td>
                               <td className="px-6 py-3">
                                 <div className="flex items-center gap-1">
                                   <Button variant="ghost" size="sm" onClick={() => setEditing({ ...m })} className="text-gray-700 hover:text-gray-900">View</Button>
                                   <Button variant="ghost" size="sm" onClick={() => setEditing({ ...m })} className="text-blue-600 hover:text-blue-800"><Edit3 className="w-4 h-4"/></Button>
-                                  <Button variant="ghost" size="sm" onClick={async () => { try { await resendUserInvite((m as any).email); toast({ title: 'Invite sent', description: `Password reset link sent to ${(m as any).email}` }); } catch (e: any) { toast({ title: 'Failed to send invite', description: e.message || 'Please try again.' }); } }} className="text-gray-600 hover:text-gray-800"><Key className="w-4 h-4"/></Button>
+                                  <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    onClick={async () => {
+                                      try {
+                                        await resendUserInvite((m as any).email);
+                                        toast({ title: 'Invite sent', description: `Password reset link sent to ${(m as any).email}` });
+                                      } catch (e: any) {
+                                        toast({ title: 'Failed to send invite', description: e.message || 'Please try again.' });
+                                      }
+                                    }}
+                                    className="text-gray-600 hover:text-gray-800"
+                                  >
+                                    <Key className="w-4 h-4"/>
+                                  </Button>
                                   <Button variant="ghost" size="sm" className="text-red-600 hover:text-red-800" onClick={() => handleDeleteMember(m)}><Trash2 className="w-4 h-4"/></Button>
                                 </div>
                               </td>
@@ -1495,21 +1512,7 @@ const AccessTab = ({ loading = false, error, setError, onTabChange, onEditUser }
 
   return (
     <div className="space-y-6">
-      {/* Header Section */}
-      <div className="bg-gradient-to-r from-green-600 to-teal-600 rounded-2xl p-8 text-white shadow-lg">
-        <div className="flex items-center justify-between">
-          <div>
-            <h1 className="text-3xl font-bold mb-2">Access Control</h1>
-            <p className="text-green-100">Manage user access and system permissions</p>
-          </div>
-          <div className="flex items-center space-x-4">
-            <div className="bg-white/20 rounded-xl p-4">
-              <Shield className="w-8 h-8" />
-            </div>
-          </div>
-        </div>
-      </div>
-
+     
       {/* Error Display */}
       {error && (
         <div className="bg-red-50 border border-red-200 rounded-xl p-4 flex items-center space-x-3">
@@ -1578,36 +1581,41 @@ const AccessTab = ({ loading = false, error, setError, onTabChange, onEditUser }
                 className="pl-10"
               />
             </div>
-                  <option value="all">All Status</option>
-                  <option value="active">Active</option>
-                  <option value="inactive">Inactive</option>
-                  <option value="pending">Pending</option>
-                </select>
-              </div>
-              {/* Export dropdown in toolbar */}
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button variant="outline" className="flex items-center space-x-2">
-                    <Download className="w-4 h-4" />
-                    <span>Export</span>
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuItem onClick={() => handleExportAs('csv')}>
-                    <FileText className="w-4 h-4 mr-2" />
-                    Export as CSV
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => handleExportAs('xlsx')}>
-                    <FileSpreadsheet className="w-4 h-4 mr-2" />
-                    Export as Excel (XLSX)
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => handleExportAs('pdf')}>
-                    <File className="w-4 h-4 mr-2" />
-                    Export as PDF
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
+            <div className="md:w-64">
+              <select
+                className="w-full px-3 py-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-transparent"
+                value={filterStatus}
+                onChange={(e) => setFilterStatus(e.target.value)}
+              >
+                <option value="all">All Status</option>
+                <option value="active">Active</option>
+                <option value="inactive">Inactive</option>
+                <option value="pending">Pending</option>
+              </select>
             </div>
+            {/* Export dropdown in toolbar */}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline" className="flex items-center space-x-2">
+                  <Download className="w-4 h-4" />
+                  <span>Export</span>
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={() => handleExportAs('csv')}>
+                  <FileText className="w-4 h-4 mr-2" />
+                  Export as CSV
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => handleExportAs('xlsx')}>
+                  <FileSpreadsheet className="w-4 h-4 mr-2" />
+                  Export as Excel (XLSX)
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => handleExportAs('pdf')}>
+                  <File className="w-4 h-4 mr-2" />
+                  Export as PDF
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
         </div>
       )}

--- a/src/components/dashboard/Sidebar.tsx
+++ b/src/components/dashboard/Sidebar.tsx
@@ -15,7 +15,8 @@ import {
   BarChart3,
   PlusSquare,
   Bell,
-  ShieldCheck
+  ShieldCheck,
+  FolderTree
 } from "lucide-react";
 import dentalLogo from "@/assets/dentpal_logo.png";
 import { useAuth } from "@/hooks/use-auth";
@@ -38,6 +39,7 @@ const menuItems = [
   { id: "add-product", label: "Add Product", icon: PlusSquare },
   { id: "product-qc", label: "QC Product", icon: CheckCircle },
   { id: "warranty", label: "Warranty", icon: ShieldCheck },
+  { id: "categories", label: "Categories", icon: FolderTree },
   { id: "confirmation", label: "Confirmation", icon: CheckCircle },
   { id: "withdrawal", label: "Withdrawal", icon: CreditCard },
   { id: "sub-accounts", label: "Sub Account", icon: Users },
@@ -69,6 +71,7 @@ const Sidebar = ({ activeItem, onItemClick, onLogout }: SidebarProps) => {
     'add-product': 'add-product',
     'product-qc': 'product-qc',
     warranty: 'warranty',
+    categories: 'categories',
     confirmation: "confirmation",
     withdrawal: "withdrawal",
     'sub-accounts': 'dashboard',
@@ -86,6 +89,9 @@ const Sidebar = ({ activeItem, onItemClick, onLogout }: SidebarProps) => {
         let permitted = menuItems.filter((item) => {
           if (item.id === 'product-qc' && !isAdmin) return false;
           if (item.id === 'warranty' && !isAdmin) return false;
+          if (item.id === 'categories' && !isAdmin) return false;
+          // TEMP: hide seller tabs from admin panel
+          if (isAdmin && ['seller-orders','inventory','add-product','sub-accounts'].includes(item.id)) return false;
           const key = permissionByMenuId[item.id];
 
           // For sub-accounts: only show items that have an explicit permission flag and it's true

--- a/src/components/images/ImagesTab.tsx
+++ b/src/components/images/ImagesTab.tsx
@@ -490,21 +490,6 @@ const ImagesTab = ({ loading = false, error, setError, onTabChange }: ImagesTabP
 
   return (
     <div className="space-y-8" onDragEnter={handleDrag} onDragLeave={handleDrag} onDragOver={handleDrag}>
-      {/* Header Section */}
-      <div className="bg-gradient-to-r from-teal-600 to-cyan-600 rounded-2xl p-8 text-white shadow-lg">
-        <div className="flex items-center justify-between">
-          <div>
-            <h1 className="text-3xl font-bold mb-2">Images Management</h1>
-            <p className="text-teal-100">Manage promotional images, banners, and pop-up assets</p>
-          </div>
-          <div className="flex items-center space-x-4">
-            <div className="bg-white/20 rounded-xl p-4">
-              <ImageIcon className="w-8 h-8" />
-            </div>
-          </div>
-        </div>
-      </div>
-
       {/* Error Display */}
       {error && (
         <div className="bg-red-50 border border-red-200 rounded-xl p-4 flex items-center space-x-3">

--- a/src/hooks/use-auth.tsx
+++ b/src/hooks/use-auth.tsx
@@ -22,6 +22,10 @@ export const PERMISSIONS_BY_ROLE: Record<WebUserRole, WebUserPermissions> = {
     'add-product': true,
     'product-qc': true,
     reports: true,
+    // NEW: warranty tab default for admin
+    warranty: true,
+    // NEW: categories manager (admin only)
+    categories: true,
   },
   seller: {
     dashboard: true,
@@ -36,6 +40,10 @@ export const PERMISSIONS_BY_ROLE: Record<WebUserRole, WebUserPermissions> = {
     'add-product': true,
     'product-qc': false,
     reports: true,
+    // NEW: warranty hidden for sellers
+    warranty: false,
+    // NEW: categories hidden for sellers
+    categories: false,
   }
 };
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -24,6 +24,7 @@ import AddProduct from '@/pages/AddProduct'; // New
 import NotificationsTab from '@/components/notifications/NotificationsTab';
 import { useLocation, useNavigate } from 'react-router-dom';
 import WarrantyManager from '@/pages/admin/WarrantyManager';
+import CategoryManager from '@/pages/admin/CategoryManager';
 
 interface DashboardProps {
   user: { name?: string; email: string };
@@ -237,6 +238,10 @@ const Dashboard = ({ user, onLogout }: DashboardProps) => {
     notifications: 'dashboard',
     // NEW: Admin QC tab permission mapping
     'product-qc': 'product-qc',
+    // NEW: Warranty tab mapping (admin-only in UI; permission optional)
+    'warranty': 'warranty',
+    // NEW: Categories tab mapping (admin-only)
+    'categories': 'categories',
   } as any;
 
   const isAllowed = (itemId: string) => hasPermission((permissionByMenuId[itemId] || 'dashboard') as any);
@@ -826,6 +831,14 @@ const Dashboard = ({ user, onLogout }: DashboardProps) => {
         return (
           <AddProduct />
         );
+      // NEW: Admin Warranty tab
+      case 'warranty':
+        if (!isAdmin) return <div className="p-6 bg-white rounded-xl border">Access denied</div>;
+        return <WarrantyManager />;
+      // NEW: Admin Categories tab
+      case 'categories':
+        if (!isAdmin) return <div className="p-6 bg-white rounded-xl border">Access denied</div>;
+        return <CategoryManager />;
       default:
         return null;
     }
@@ -846,6 +859,10 @@ const Dashboard = ({ user, onLogout }: DashboardProps) => {
       case "sub-accounts": return "Sub Account";
       case "images": return "Images";
       case "users": return "Users";
+      // NEW: Warranty title
+      case 'warranty': return 'Warranty';
+      // NEW: Categories title
+      case 'categories': return 'Categories';
       default: return "Dashboard";
     }
   };
@@ -878,6 +895,12 @@ const Dashboard = ({ user, onLogout }: DashboardProps) => {
         return "Manage dental images, x-rays, and patient photos";
       case "users":
         return "Manage patients, staff, and user accounts";
+      // NEW: Warranty subtitle
+      case 'warranty':
+        return 'Set warranty durations by category and subcategory';
+      // NEW: Categories subtitle
+      case 'categories':
+        return 'Create, rename, and delete categories and their subcategories';
       default:
         return "";
     }

--- a/src/pages/admin/CategoryManager.tsx
+++ b/src/pages/admin/CategoryManager.tsx
@@ -1,0 +1,343 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useToast } from '@/hooks/use-toast';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { FolderTree, Plus, Pencil, Trash2, Search } from 'lucide-react';
+import CategoryService, { Category, Subcategory } from '@/services/category';
+
+const toTitle = (s: string) => s.replace(/\s+/g, ' ').trim().replace(/(^|\s)\S/g, (t) => t.toUpperCase());
+
+const CategoryManager: React.FC = () => {
+  const { toast } = useToast();
+  const [loading, setLoading] = useState(true);
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [filter, setFilter] = useState('');
+
+  // Subcategories for selected category
+  const [subs, setSubs] = useState<Subcategory[]>([]);
+  const [subsLoading, setSubsLoading] = useState(false);
+
+  // Dialogs
+  const [addCatOpen, setAddCatOpen] = useState(false);
+  const [editCatOpen, setEditCatOpen] = useState<null | Category>(null);
+  const [deleteCatOpen, setDeleteCatOpen] = useState<null | Category>(null);
+  const [catName, setCatName] = useState('');
+
+  const [addSubOpen, setAddSubOpen] = useState(false);
+  const [editSubOpen, setEditSubOpen] = useState<null | Subcategory>(null);
+  const [deleteSubOpen, setDeleteSubOpen] = useState<null | Subcategory>(null);
+  const [subName, setSubName] = useState('');
+
+  useEffect(() => {
+    const unsub = CategoryService.listenCategories((rows) => {
+      setCategories(rows);
+      setLoading(false);
+      if (!selectedId && rows.length) setSelectedId(rows[0].id);
+    }, (err) => {
+      console.error('Failed to load categories', err);
+      setLoading(false);
+      toast({ title: 'Failed to load categories', description: 'Please check your Firestore rules and collection name "Category".', variant: 'destructive' });
+    });
+    return () => unsub();
+  }, []);
+
+  // Load subcategories when selection changes
+  useEffect(() => {
+    if (!selectedId) { setSubs([]); return; }
+    setSubsLoading(true);
+    const unsub = CategoryService.listenSubcategories(selectedId, (rows) => {
+      setSubs(rows);
+      setSubsLoading(false);
+    }, (err) => {
+      console.error('Failed to load subcategories', err);
+      setSubs([]);
+      setSubsLoading(false);
+    });
+    return () => unsub();
+  }, [selectedId]);
+
+  const filteredCategories = useMemo(() => {
+    const t = filter.trim().toLowerCase();
+    if (!t) return categories;
+    return categories.filter((c) => c.name.toLowerCase().includes(t));
+  }, [categories, filter]);
+
+  const openAddCategory = () => { setCatName(''); setAddCatOpen(true); };
+  const openEditCategory = (c: Category) => { setCatName(c.name); setEditCatOpen(c); };
+  const openDeleteCategory = (c: Category) => { setDeleteCatOpen(c); };
+
+  const confirmAddCategory = async () => {
+    const name = toTitle(catName);
+    try {
+      await CategoryService.addCategory(name);
+      setAddCatOpen(false);
+      toast({ title: 'Category added', description: `${name} created.` });
+    } catch (e: any) {
+      toast({ title: 'Failed to add category', description: e.message || 'Try again.', variant: 'destructive' });
+    }
+  };
+
+  const confirmEditCategory = async () => {
+    const c = editCatOpen; if (!c) return;
+    const name = toTitle(catName);
+    try {
+      await CategoryService.updateCategory(c.id, name);
+      setEditCatOpen(null);
+      toast({ title: 'Category updated', description: `${name} saved.` });
+    } catch (e: any) {
+      toast({ title: 'Failed to update category', description: e.message || 'Try again.', variant: 'destructive' });
+    }
+  };
+
+  const confirmDeleteCategory = async () => {
+    const c = deleteCatOpen; if (!c) return;
+    try {
+      await CategoryService.deleteCategory(c.id);
+      setDeleteCatOpen(null);
+      if (selectedId === c.id) setSelectedId(null);
+      toast({ title: 'Category deleted', description: `${c.name} removed.` });
+    } catch (e: any) {
+      toast({ title: 'Failed to delete category', description: e.message || 'Try again.', variant: 'destructive' });
+    }
+  };
+
+  const openAddSub = () => { setSubName(''); setAddSubOpen(true); };
+  const openEditSub = (s: Subcategory) => { setSubName(s.name); setEditSubOpen(s); };
+  const openDeleteSub = (s: Subcategory) => { setDeleteSubOpen(s); };
+
+  const confirmAddSub = async () => {
+    if (!selectedId) return;
+    const name = toTitle(subName);
+    try {
+      await CategoryService.addSubcategory(selectedId, name);
+      setAddSubOpen(false);
+      toast({ title: 'Subcategory added', description: `${name} created.` });
+    } catch (e: any) {
+      toast({ title: 'Failed to add subcategory', description: e.message || 'Try again.', variant: 'destructive' });
+    }
+  };
+
+  const confirmEditSub = async () => {
+    const s = editSubOpen; if (!s || !selectedId) return;
+    const name = toTitle(subName);
+    try {
+      await CategoryService.updateSubcategory(selectedId, s.id, name);
+      setEditSubOpen(null);
+      toast({ title: 'Subcategory updated', description: `${name} saved.` });
+    } catch (e: any) {
+      toast({ title: 'Failed to update subcategory', description: e.message || 'Try again.', variant: 'destructive' });
+    }
+  };
+
+  const confirmDeleteSub = async () => {
+    const s = deleteSubOpen; if (!s || !selectedId) return;
+    try {
+      await CategoryService.deleteSubcategory(selectedId, s.id);
+      setDeleteSubOpen(null);
+      toast({ title: 'Subcategory deleted', description: `${s.name} removed.` });
+    } catch (e: any) {
+      toast({ title: 'Failed to delete subcategory', description: e.message || 'Try again.', variant: 'destructive' });
+    }
+  };
+
+  const selectedCategory = categories.find(c => c.id === selectedId) || null;
+
+  return (
+    <div className="space-y-6">
+      {/* Hero/Header */}
+      <div className="bg-gradient-to-r from-green-600 to-teal-600 rounded-2xl p-6 text-white shadow">
+        <div className="flex items-center justify-between">
+          
+          <Button onClick={openAddCategory} className="bg-white text-green-700 hover:bg-green-50">
+            New Category
+          </Button>
+        </div>
+      </div>
+
+      {/* Main content: two tables */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        {/* Categories table */}
+        <div className="bg-white rounded-2xl border border-gray-200 shadow-sm p-0 overflow-hidden">
+          <div className="p-4 border-b flex items-center gap-2">
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+              <Input value={filter} onChange={(e)=> setFilter(e.target.value)} placeholder="Search category..." className="pl-9" />
+            </div>
+          </div>
+          <div className="overflow-auto">
+            <table className="w-full text-sm">
+              <thead className="bg-gray-50 text-gray-600">
+                <tr>
+                  <th className="text-left px-4 py-2 font-medium">Name</th>
+                  <th className="text-right px-4 py-2 font-medium">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {loading ? (
+                  <tr><td colSpan={2} className="px-4 py-8 text-center text-gray-500">Loading…</td></tr>
+                ) : filteredCategories.length === 0 ? (
+                  <tr><td colSpan={2} className="px-4 py-8 text-center text-gray-500">No categories found</td></tr>
+                ) : (
+                  filteredCategories.map((c) => (
+                    <tr key={c.id} className={`hover:bg-gray-50 cursor-pointer ${selectedId===c.id? 'bg-gray-50' : ''}`}
+                        onClick={()=> setSelectedId(c.id)}>
+                      <td className="px-4 py-2">{c.name}</td>
+                      <td className="px-4 py-2">
+                        <div className="flex items-center justify-end gap-1">
+                          <Button variant="ghost" size="sm" onClick={(e)=> { e.stopPropagation(); openEditCategory(c); }}><Pencil className="w-4 h-4"/></Button>
+                          <Button variant="ghost" size="sm" onClick={(e)=> { e.stopPropagation(); openDeleteCategory(c); }} className="text-red-600 hover:text-red-800"><Trash2 className="w-4 h-4"/></Button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        {/* Subcategories table */}
+        <div className="md:col-span-2 bg-white rounded-2xl border border-gray-200 shadow-sm p-0 overflow-hidden">
+          <div className="p-4 border-b flex items-center justify-between">
+            <div>
+              <div className="text-sm font-semibold text-gray-900">{selectedCategory ? selectedCategory.name : 'Subcategories'}</div>
+              <div className="text-xs text-gray-500">{selectedCategory ? 'Subcategories under this category' : 'Select a category to manage its subcategories'}</div>
+            </div>
+            <Button onClick={openAddSub} disabled={!selectedCategory} className="bg-green-600 hover:bg-green-700 text-white">New Subcategory</Button>
+          </div>
+          <div className="overflow-auto">
+            <table className="w-full text-sm">
+              <thead className="bg-gray-50 text-gray-600">
+                <tr>
+                  <th className="text-left px-4 py-2 font-medium">Name</th>
+                  <th className="text-right px-4 py-2 font-medium">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {!selectedCategory ? (
+                  <tr><td colSpan={2} className="px-4 py-12 text-center text-gray-500">Select a category to manage its subcategories</td></tr>
+                ) : subsLoading ? (
+                  <tr><td colSpan={2} className="px-4 py-12 text-center text-gray-500">Loading…</td></tr>
+                ) : subs.length === 0 ? (
+                  <tr><td colSpan={2} className="px-4 py-12 text-center text-gray-500">No subcategories</td></tr>
+                ) : (
+                  subs.map((s) => (
+                    <tr key={s.id}>
+                      <td className="px-4 py-2">{s.name}</td>
+                      <td className="px-4 py-2">
+                        <div className="flex items-center justify-end gap-1">
+                          <Button variant="ghost" size="sm" onClick={()=> openEditSub(s)}><Pencil className="w-4 h-4"/></Button>
+                          <Button variant="ghost" size="sm" onClick={()=> openDeleteSub(s)} className="text-red-600 hover:text-red-800"><Trash2 className="w-4 h-4"/></Button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      {/* Add Category */}
+      <Dialog open={addCatOpen} onOpenChange={setAddCatOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>New Category</DialogTitle>
+            <DialogDescription>Create a new top-level category</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <Input autoFocus value={catName} onChange={(e)=> setCatName(e.target.value)} placeholder="e.g. Orthodontics" />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={()=> setAddCatOpen(false)}>Cancel</Button>
+            <Button onClick={confirmAddCategory} className="bg-green-600 hover:bg-green-700 text-white">Create</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Edit Category */}
+      <Dialog open={!!editCatOpen} onOpenChange={(o)=> !o && setEditCatOpen(null)}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Edit Category</DialogTitle>
+            <DialogDescription>Rename this category</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <Input autoFocus value={catName} onChange={(e)=> setCatName(e.target.value)} />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={()=> setEditCatOpen(null)}>Cancel</Button>
+            <Button onClick={confirmEditCategory} className="bg-green-600 hover:bg-green-700 text-white">Save</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete Category */}
+      <Dialog open={!!deleteCatOpen} onOpenChange={(o)=> !o && setDeleteCatOpen(null)}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Delete Category</DialogTitle>
+            <DialogDescription>This will also delete all its subcategories. This action cannot be undone.</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={()=> setDeleteCatOpen(null)}>Cancel</Button>
+            <Button onClick={confirmDeleteCategory} className="bg-red-600 hover:bg-red-700 text-white">Delete</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Add Subcategory */}
+      <Dialog open={addSubOpen} onOpenChange={setAddSubOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>New Subcategory</DialogTitle>
+            <DialogDescription>Add a subcategory under {selectedCategory?.name}</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <Input autoFocus value={subName} onChange={(e)=> setSubName(e.target.value)} placeholder="e.g. Brackets" />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={()=> setAddSubOpen(false)}>Cancel</Button>
+            <Button onClick={confirmAddSub} className="bg-green-600 hover:bg-green-700 text-white">Create</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Edit Subcategory */}
+      <Dialog open={!!editSubOpen} onOpenChange={(o)=> !o && setEditSubOpen(null)}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Edit Subcategory</DialogTitle>
+            <DialogDescription>Rename this subcategory</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <Input autoFocus value={subName} onChange={(e)=> setSubName(e.target.value)} />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={()=> setEditSubOpen(null)}>Cancel</Button>
+            <Button onClick={confirmEditSub} className="bg-green-600 hover:bg-green-700 text-white">Save</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete Subcategory */}
+      <Dialog open={!!deleteSubOpen} onOpenChange={(o)=> !o && setDeleteSubOpen(null)}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Delete Subcategory</DialogTitle>
+            <DialogDescription>This action cannot be undone.</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={()=> setDeleteSubOpen(null)}>Cancel</Button>
+            <Button onClick={confirmDeleteSub} className="bg-red-600 hover:bg-red-700 text-white">Delete</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};
+
+export default CategoryManager;

--- a/src/services/category.ts
+++ b/src/services/category.ts
@@ -1,0 +1,76 @@
+import { db } from '@/lib/firebase';
+import { addDoc, collection, deleteDoc, doc, getDocs, onSnapshot, serverTimestamp, updateDoc } from 'firebase/firestore';
+
+export type Category = { id: string; name: string };
+export type Subcategory = { id: string; name: string };
+
+const normalizeName = (raw: any, fallBackId: string) => {
+  return String(
+    raw?.name || raw?.categoryName || raw?.CategoryName || raw?.category || raw?.Category || raw?.title || raw?.displayName || raw?.label || fallBackId
+  ).trim();
+};
+
+export const CategoryService = {
+  listenCategories: (cb: (rows: Category[]) => void, onError?: (e: any) => void) => {
+    const col = collection(db, 'Category');
+    return onSnapshot(col, (snap) => {
+      const rows = snap.docs
+        .map(d => ({ id: d.id, name: normalizeName(d.data(), d.id) }))
+        .sort((a, b) => a.name.localeCompare(b.name));
+      cb(rows);
+    }, onError);
+  },
+
+  listenSubcategories: (categoryId: string, cb: (rows: Subcategory[]) => void, onError?: (e: any) => void) => {
+    const col = collection(db, 'Category', categoryId, 'subCategory');
+    return onSnapshot(col, (snap) => {
+      const rows = snap.docs
+        .map(d => {
+          const data: any = d.data();
+          const name = String(
+            data?.subCategoryName || data?.subcategoryName || data?.name || data?.title || data?.displayName || data?.label || d.id
+          ).trim();
+          return { id: d.id, name } as Subcategory;
+        })
+        .filter(r => !!r.name)
+        .sort((a, b) => a.name.localeCompare(b.name));
+      cb(rows);
+    }, onError);
+  },
+
+  addCategory: async (name: string) => {
+    const v = name.trim();
+    if (!v) throw new Error('Name is required');
+    await addDoc(collection(db, 'Category'), { name: v, categoryName: v, createdAt: serverTimestamp() });
+  },
+
+  updateCategory: async (id: string, name: string) => {
+    const v = name.trim();
+    if (!v) throw new Error('Name is required');
+    await updateDoc(doc(db, 'Category', id), { name: v, categoryName: v, updatedAt: serverTimestamp() });
+  },
+
+  deleteCategory: async (id: string) => {
+    const subs = await getDocs(collection(db, 'Category', id, 'subCategory'));
+    await Promise.allSettled(subs.docs.map((d) => deleteDoc(doc(db, 'Category', id, 'subCategory', d.id))));
+    await deleteDoc(doc(db, 'Category', id));
+  },
+
+  addSubcategory: async (categoryId: string, name: string) => {
+    const v = name.trim();
+    if (!v) throw new Error('Name is required');
+    await addDoc(collection(db, 'Category', categoryId, 'subCategory'), { name: v, subCategoryName: v, createdAt: serverTimestamp() });
+  },
+
+  updateSubcategory: async (categoryId: string, subId: string, name: string) => {
+    const v = name.trim();
+    if (!v) throw new Error('Name is required');
+    await updateDoc(doc(db, 'Category', categoryId, 'subCategory', subId), { name: v, subCategoryName: v, updatedAt: serverTimestamp() });
+  },
+
+  deleteSubcategory: async (categoryId: string, subId: string) => {
+    await deleteDoc(doc(db, 'Category', categoryId, 'subCategory', subId));
+  },
+};
+
+export default CategoryService;

--- a/src/types/webUser.ts
+++ b/src/types/webUser.ts
@@ -13,6 +13,8 @@ export type WebUserPermissions = {
   'add-product': boolean; // New: Allow access to Add Product/Manage Product
   'product-qc': boolean; // New: Admin Pending QC tab
   reports: boolean; // New: Reports visibility
+  warranty: boolean; // NEW: Admin Warranty tab
+  categories?: boolean; // NEW: Admin Categories tab (optional, admin-only)
 };
 
 export interface WebUserProfile {


### PR DESCRIPTION
feat(admin): add Categories manager (CRUD with subcategories)\n\n- New admin tab and routing\n- Real-time Firestore listeners for Category and subCategory\n- Table UI, dialogs for add/edit/delete\n- Single-responsibility refactor via CategoryService\n- Permissions updated (admin-only)\n- Prefer subCategoryName for subcategories\n- Minor Sidebar mapping and gating updates