### PR TITLE
feat(admin-dashboard): add filtered metrics based on date, province, …

### DIFF
--- a/src/lib/phLocations.ts
+++ b/src/lib/phLocations.ts
@@ -224,7 +224,12 @@ export const getProvinces = async (): Promise<Province[]> => {
   return list ?? provinces.slice();
 };
 
+const citiesCache = new Map<string, City[]>();
 export const getCitiesByProvinceAsync = async (provinceCode: string): Promise<City[]> => {
+  // Return from memory cache if available
+  if (citiesCache.has(provinceCode)) {
+    return citiesCache.get(provinceCode)!;
+  }
   try {
     // Try to load cities directly from select-philippines-address for this province
     const selectMod: any = await import('select-philippines-address');
@@ -239,6 +244,7 @@ export const getCitiesByProvinceAsync = async (provinceCode: string): Promise<Ci
       })).sort((a: City, b: City) => a.name.localeCompare(b.name));
       
       console.log('[phLocations] Loaded cities for province', provinceCode, ':', citiesList.length);
+      citiesCache.set(provinceCode, citiesList);
       return citiesList;
     }
   } catch (e) {


### PR DESCRIPTION
Filtered metrics based on date, province, city, and seller

- Updated admin metrics to filter by date range, province, city, and shop name
- Changed 'Order Shipped' metric from average order value to count of shipped orders
- Shipped orders now tracked via statusHistory (shipping/shipped status)
- Metrics now dynamically update based on admin filter selections
- Added comprehensive console logging for debugging filtered metrics
- Moved adminSelectedCityCodes state declaration to the proper location

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin dashboard now displays order metrics (total, delivered, and shipped orders).
  * Admins can filter orders by multiple cities using a new multi-select city filter.

* **Performance**
  * Improved city data loading speed with enhanced caching.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->