### PR TITLE
feat: Update sub-account permissions and add fragile field to product…

### DIFF
--- a/src/services/product.ts
+++ b/src/services/product.ts
@@ -176,6 +176,7 @@ export const ProductService = {
     dimensions?: { length?: number; width?: number; height?: number } | null;
     imageURL?: string | null;
     name?: string;
+    isFragile?: boolean;
   }>) {
     const col = collection(db, PRODUCT_COLLECTION, productId, 'Variation');
     const tasks = variations.map(v => {
@@ -202,6 +203,7 @@ export const ProductService = {
         dimensions: dim ?? null,
         imageURL: v.imageURL ?? null,
         name: v.name ?? null,
+        isFragile: v.isFragile ?? false,
         productId,
         createdAt: serverTimestamp(),
         updatedAt: serverTimestamp(),
@@ -463,6 +465,7 @@ export const ProductService = {
     dimensions?: { length?: number; width?: number; height?: number };
     dimensionsUnit?: string;
     imageURL?: string;
+    isFragile?: boolean;
   }) {
     const vRef = doc(db, PRODUCT_COLLECTION, productId, 'Variation', variationId);
     const updateData: any = {
@@ -480,6 +483,7 @@ export const ProductService = {
     if (updates.weightUnit !== undefined) updateData.weightUnit = updates.weightUnit;
     if (updates.dimensionsUnit !== undefined) updateData.dimensionsUnit = updates.dimensionsUnit;
     if (updates.imageURL !== undefined) updateData.imageURL = updates.imageURL;
+    if (updates.isFragile !== undefined) updateData.isFragile = updates.isFragile;
     
     if (updates.dimensions) {
       updateData.dimensions = updates.dimensions;


### PR DESCRIPTION
- Renamed 'Dashboard' to 'Sales Summary' in sub-account permissions
- Removed 'Booking' and 'Notifications' from sub-account permissions
- Added 'Inventory Control' permission tab
- Renamed 'Add Product' to 'Items' in sub-account permissions
- Made View Sub-account modal read-only (separate from Edit modal)
- Added 'isFragile' boolean field to product variations
- Added Fragile checkbox column in Items tab (AddProduct and InventoryTab)
- Integrated isFragile field with Firebase Product > Variation subcollection
- Updated ProductService addVariations and updateVariation to support isFragile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fragile product indicator—mark variants as fragile via checkbox in product creation and management.
  * Added read-only view mode for sub-account dialogs, allowing review without editing capabilities.

* **Improvements**
  * Permission labels now display with clearer, user-friendly terminology across the access management interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->